### PR TITLE
Add plugins to MANIFIEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,7 @@ recursive-include inginious/frontend/templates *
 recursive-include inginious/frontend/plugins/contests *
 recursive-include inginious/frontend/plugins/scoreboard *
 recursive-include inginious/frontend/plugins/auth *
+recursive-include inginious/frontend/plugins/grader_generator *
+recursive-include inginious/frontend/plugins/statistics *
+recursive-include inginious/frontend/plugins/utils *
+recursive-include inginious/frontend/plugins/multilang *


### PR DESCRIPTION
This allows production installations to keep the non python files. If we don't do this, none of the plugins would work on production