### PR TITLE
 Fix course permissions and required parameters in grader plugin

### DIFF
--- a/inginious/frontend/plugins/grader_generator/__init__.py
+++ b/inginious/frontend/plugins/grader_generator/__init__.py
@@ -13,7 +13,7 @@ _BASE_STATIC_FOLDER = os.path.join(os.path.dirname(__file__), 'static')
 def init(plugin_manager, course_factory, client, config):
     plugin_manager.add_page(r'/grader_generator/static/(.*)', create_static_resource_page(_BASE_STATIC_FOLDER))
 
-    plugin_manager.add_page('/api/stats/test_file_api', TaskTestCasesFilesApi)
+    plugin_manager.add_page('/api/grader_generator/test_file_api', TaskTestCasesFilesApi)
 
     plugin_manager.add_hook('task_editor_tab', grader_generator_tab)
     plugin_manager.add_hook('task_editor_footer', grader_footer)

--- a/inginious/frontend/plugins/grader_generator/pages/api/task_test_cases_files_api.py
+++ b/inginious/frontend/plugins/grader_generator/pages/api/task_test_cases_files_api.py
@@ -1,9 +1,10 @@
 import web
-import inginious.frontend.pages.api._api_page as api
+from inginious.frontend.plugins.utils.admin_api import AdminApi
 from inginious.frontend.pages.course_admin.task_edit_file import CourseTaskFiles
+from inginious.frontend.plugins.utils import get_mandatory_parameter
 
 
-class TaskTestCasesFilesApi(api.APIAuthenticatedPage):
+class TaskTestCasesFilesApi(AdminApi):
 
     def API_GET(self):
         """
@@ -18,8 +19,10 @@ class TaskTestCasesFilesApi(api.APIAuthenticatedPage):
         """
         parameters = web.input()
 
-        courseid = parameters["course_id"]
-        taskid = parameters["task_id"]
+        courseid = get_mandatory_parameter(parameters, "course_id")
+        taskid = get_mandatory_parameter(parameters, "task_id")
+
+        self.get_course_and_check_rights(courseid)
 
         file_list = CourseTaskFiles.get_task_filelist(self.task_factory, courseid, taskid)
         result = [

--- a/inginious/frontend/plugins/grader_generator/static/js/grader_generator.js
+++ b/inginious/frontend/plugins/grader_generator/static/js/grader_generator.js
@@ -117,7 +117,7 @@ function studio_set_initial_problem(initialProblemId){
 
 function studio_update_grader_files()
 {
-    $.get('/api/stats/test_file_api', {
+    $.get('/api/grader_generator/test_file_api', {
         course_id: courseId,
         task_id: taskId
     }, function(files) {


### PR DESCRIPTION
This PR is fixing some course permissions in the api pages and validating mandatory parameters.

This is taking new changes made in utils PR.