### PR TITLE
Change links from INGInious documentation to UNCode documentation. (Fixes #28)

### DIFF
--- a/inginious/frontend/plugins/UNCode/static/js/uncode.js
+++ b/inginious/frontend/plugins/UNCode/static/js/uncode.js
@@ -60,7 +60,22 @@ jQuery(document).ready(function () {
         }
     }
 
+    function updateCourseDocumentationLinks() {
+        // This section is to update link of "How to create task?" button in course administration.
+        // Now redirecting to our documentation.
+        let howToCreateTaskElement = $('a[href="http://inginious.readthedocs.org/en/latest/teacher_doc/task_tuto.html"]');
+        howToCreateTaskElement.attr("href", "https://github.com/JuezUN/INGInious/wiki/How-to-create-a-task");
+        howToCreateTaskElement.attr("target", "_blank");
+
+        // This section is to update link of "Documentation" button in course administration-
+        // Now redirecting to our documentation.
+        let documentationElement = $('a[href="http://inginious.readthedocs.org/en/latest/teacher_documentation.html"]');
+        documentationElement.attr("href", "https://github.com/JuezUN/INGInious/wiki/Course-administration");
+        documentationElement.attr("target", "_blank");
+    }
+
     updateTemplate();
     addTaskContextTemplate();
     addTaskContextHelp();
+    updateCourseDocumentationLinks();
 });


### PR DESCRIPTION
This PR Changes the documentation links in course administration. Now they redirect to UNCode documentation instead of INGInious one.
![image](https://user-images.githubusercontent.com/22863695/49490635-d9b49d00-f81e-11e8-9e95-152ad60fb01c.png)
