### PR TITLE
Linter fix python2 Fixes #52

### DIFF
--- a/inginious/frontend/plugins/multilang/static/codemirror_linter.js
+++ b/inginious/frontend/plugins/multilang/static/codemirror_linter.js
@@ -1,22 +1,33 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: http://codemirror.net/LICENSE
 
+function convertInginiousLanguageToLinter(inginiousLanguage) {
+  var languages = {
+      "java7": "java",
+      "java8": "java",
+      "js": "javascript",
+      "cpp": "cpp",
+      "cpp11": "cpp",
+      "c": "c",
+      "c11": "c",
+      "python2": "python2",
+      "python3": "python3",
+      "ruby": "ruby"
+  };
 
-function webLinter(language, code, callback, options, editor){
+  return languages[inginiousLanguage];
+}
+
+function webLinter(code, callback, options, editor){
+  var language = convertInginiousLanguageToLinter(editor.getOption("inginiousLanguage"));
   var lintServerUrl = getLinterServerURL() + language;
-
+ 
   var serverCallback = function(response, status){
     var errors_and_warnings = JSON.parse(response);    
     callback(errors_and_warnings);
   }
 
   $.post(lintServerUrl, {code: code}, serverCallback);
-}
-
-function linterForLanguage(language) {
-  return function(code, callback, options, editor){
-    webLinter(language, code, callback, options, editor);    
-  }
 }
 
 (function (mod) {
@@ -29,8 +40,8 @@ function linterForLanguage(language) {
 })(function (CodeMirror) {
   "use strict";
 
-  CodeMirror.registerHelper("lint", "python", linterForLanguage("python"));
-  CodeMirror.registerHelper("lint", "text/x-java", linterForLanguage("java"));
-  CodeMirror.registerHelper("lint", "text/x-c++src", linterForLanguage("cpp"));
-  CodeMirror.registerHelper("lint", "text/x-csrc", linterForLanguage("c"));
+  CodeMirror.registerHelper("lint", "python", webLinter);
+  CodeMirror.registerHelper("lint", "text/x-java", webLinter);
+  CodeMirror.registerHelper("lint", "text/x-c++src", webLinter);
+  CodeMirror.registerHelper("lint", "text/x-csrc", webLinter);
 });

--- a/inginious/frontend/plugins/multilang/static/multilang.js
+++ b/inginious/frontend/plugins/multilang/static/multilang.js
@@ -20,9 +20,12 @@ function changeSubmissionLanguage(key){
     var lintingOptions = {
         async: true
     };
+    
+    //This should be first because setOption("mode", ...) triggers callbacks that call the linter
+    editor.setOption("inginiousLanguage", getLanguageForProblemId(key));
+
     editor.setOption("mode", mode.mime);
     editor.setOption("lint", lintingOptions);
-    editor.setOption("inginiousLanguage", getLanguageForProblemId(key));
     editor.setOption("gutters",["CodeMirror-linenumbers", "CodeMirror-foldgutter", "CodeMirror-lint-markers"]);
     CodeMirror.autoLoadMode(editor, mode["mode"]);
 }

--- a/inginious/frontend/plugins/multilang/static/multilang.js
+++ b/inginious/frontend/plugins/multilang/static/multilang.js
@@ -13,7 +13,7 @@ function setDropDownWithTheRightLanguage(key, language)
 }
 
 function changeSubmissionLanguage(key){
-    var language = getLanguageForProblemId(key);
+    var language = getCodemirrorLanguageForProblemId(key);
     var editor = codeEditors[key];
     var mode = CodeMirror.findModeByName(language);
     var editor = codeEditors[key];
@@ -22,8 +22,13 @@ function changeSubmissionLanguage(key){
     };
     editor.setOption("mode", mode.mime);
     editor.setOption("lint", lintingOptions);
+    editor.setOption("inginiousLanguage", getLanguageForProblemId(key));
     editor.setOption("gutters",["CodeMirror-linenumbers", "CodeMirror-foldgutter", "CodeMirror-lint-markers"]);
     CodeMirror.autoLoadMode(editor, mode["mode"]);
+}
+
+function getCodemirrorLanguageForProblemId(key) {
+    return convertInginiousLanguageToCodemirror(getLanguageForProblemId(key));
 }
 
 function getLanguageForProblemId(key){
@@ -32,7 +37,7 @@ function getLanguageForProblemId(key){
         return "plain";
 
     var inginiousLanguage = dropDown.options[dropDown.selectedIndex].value;
-    return convertInginiousLanguageToCodemirror(inginiousLanguage);
+    return inginiousLanguage;
 }
 
 function convertInginiousLanguageToCodemirror(inginiousLanguage) {


### PR DESCRIPTION
Fixes #52 

It was needed to put a new option on the editor object called "inginiousLanguage" because codemirror does not differentiate between python2 and python3 at the mode level.

