### PR TITLE
Change 'tools' buttons color and text

### DIFF
--- a/inginious/frontend/plugins/multilang/problems/templates/tools.html
+++ b/inginious/frontend/plugins/multilang/problems/templates/tools.html
@@ -29,10 +29,10 @@ $def with (inputId, language, customInputId, type, pythonTutorURL, linterURL)
 
       $if type == "code_multiple_languages":
           <div class="col-md-6">
-            <button type="button" class="btn btn-default btn-md btn-block" onclick="runCustomTest('$inputId')">Test</button>
+            <button type="button" class="btn btn-primary btn-md btn-block" onclick="runCustomTest('$inputId')">Test code!</button>
           </div>
           <div class="col-md-6">
-            <button class="btn btn-default btn-md btn-block" type="button" data-toggle="modal" data-target="#modal-$inputId" onclick="visualizeCode('$language', '$inputId')">Visualize</button>
+            <button class="btn btn-success btn-md btn-block" type="button" data-toggle="modal" data-target="#modal-$inputId" onclick="visualizeCode('$language', '$inputId')">Visualize your code!</button>
           </div>
 
           <div id="modal-$inputId" class="modal modal-wide fade">


### PR DESCRIPTION
Result:
![image](https://user-images.githubusercontent.com/22863695/64666183-f4095000-d41a-11e9-8595-f459582f331e.png)

The buttons look nicer and more intuitive to use.

Fix #30 