### PR TITLE
Problem bank - Fix search resets when a task is copied 

### DIFF
--- a/inginious/frontend/plugins/problem_bank/react_app/src/bank_page.jsx
+++ b/inginious/frontend/plugins/problem_bank/react_app/src/bank_page.jsx
@@ -213,11 +213,10 @@ class BankPage extends React.Component {
         });
     }
 
-    addTaskToCourse(targetId, taskId, bankId){
+    addTaskToCourse(targetId, taskId, bankId, query){
         $.post( "/plugins/problems_bank/api/copy_task",
             {"target_id": targetId, "task_id": taskId, "bank_id": bankId} ,( data ) => {
-
-            this.updateTasksAsync();
+            this.updateFilteredTasksAsync(query);
         }).done((data) => {
             this.setState( {
                 dataAlertTaskList:{

--- a/inginious/frontend/plugins/problem_bank/react_app/src/task_list.jsx
+++ b/inginious/frontend/plugins/problem_bank/react_app/src/task_list.jsx
@@ -32,6 +32,10 @@ class TaskList extends React.Component{
         }
     };
 
+    addTaskToCourse = (courseId, taskId, bankId) => {
+        this.props.callBackAddTaskToCourse(courseId, taskId, bankId, this.state.query);
+    };
+
     getListOfTasks = () => {
         let tasks = this.props.tasks.map((task, i) => {
             let page = this.props.page;
@@ -43,7 +47,7 @@ class TaskList extends React.Component{
                     task_info={task}
                     key={i}
                     courses={this.props.courses}
-                    callBackAddTaskToCourse={this.props.callBackAddTaskToCourse}
+                    callBackAddTaskToCourse={this.addTaskToCourse}
                 />)
             }
         });


### PR DESCRIPTION
When a task is copied the filtered tasks are reset so all tasks are shown event though the text query still is there. Fix #111.

Now, Instead of loading again all tasks, the filtered tasks are updated.