### PR TITLE
Fix password and template in Register students plugin

### DIFF
--- a/inginious/frontend/plugins/register_students/pages/api/add_course_students_csv_file_api.py
+++ b/inginious/frontend/plugins/register_students/pages/api/add_course_students_csv_file_api.py
@@ -88,6 +88,7 @@ class AddCourseStudentsCsvFile(AdminApi):
         if existing_user is not None:
             success = False
         else:
+            password = data["password"]
             passwd_hash = hashlib.sha512(data["password"].encode("utf-8")).hexdigest()
             activate_hash = hashlib.sha512(str(random.getrandbits(256)).encode("utf-8")).hexdigest()
             data = {"username": data["username"],
@@ -103,7 +104,7 @@ class AddCourseStudentsCsvFile(AdminApi):
                 content = str(
                     self.template_helper.get_custom_renderer(_static_folder_path, False).email_template()).format(
                     activation_link=activate_account_link, username=data["username"],
-                    password=data["password"], course_name=course.get_name("en"))
+                    password=password, course_name=course.get_name("en"))
                 subject = _("Welcome on UNCode")
                 headers = {"Content-Type": 'text/html'}
                 web.sendmail(web.config.smtp_sendername, data["email"], subject, content, headers)

--- a/inginious/frontend/plugins/register_students/static/email_template.html
+++ b/inginious/frontend/plugins/register_students/static/email_template.html
@@ -4,6 +4,9 @@
         <h2>$:_("Welcome on UNCode")</h2>
         $:_("You have been registered for the course: <strong>{course_name}</strong> at Universidad Nacional de Colombia.")
         <br><br>
+        $:_("To activate your account, please click on the following link:")
+        {activation_link}
+        <br><br>
         $:_("After you active the account, you can login to UNCode using next credentials:")
         <br><br>
         $:_("Username"): <strong>{username}</strong><br>

--- a/inginious/frontend/plugins/register_students/static/email_template.html
+++ b/inginious/frontend/plugins/register_students/static/email_template.html
@@ -2,11 +2,7 @@
     <head></head>
     <body>
         <h2>$:_("Welcome on UNCode")</h2>
-        <br><br>
         $:_("You have been registered for the course: <strong>{course_name}</strong> at Universidad Nacional de Colombia.")
-        <br><br>
-        $:_("To activate your account, please click on the following link:")
-        {activation_link}
         <br><br>
         $:_("After you active the account, you can login to UNCode using next credentials:")
         <br><br>
@@ -21,7 +17,7 @@
             <li>$:_("Click on 'Preferences' option.")</li>
             <li>$:_("Now you can change your password setting your current password and the new password.")</li>
         </ol>
-        <br><br>
+        <br>
         <i>$:_("How to authenticate using Google Authentication method?")</i><br>
         <ol>
             <li>$:_("In top nav bar, click on the option displaying your name.")</li>
@@ -29,8 +25,6 @@
             <li>$:_("To add the Google Authentication method, select 'Google' then click on 'Add new binding' button.")</li>
             <li>$:_("After adding Google Authentication you can log in to UNCode using either the normal Authentication (username and password) or Google Authentication.")</li>
         </ol>
-        <br><br>
-
         <h4><strong>$:_("Code and learn!")</strong></h4>
         <h4><strong>UNCode team.</strong></h4>
     </body>


### PR DESCRIPTION
# Description

Bug in Register students plugin. When email is sent, the password hash is sent rather than the actual password.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
