### PR TITLE
Ensure web.py uses v0.40

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "docutils>=0.14",
     "pymongo>=3.2.2",
     "PyYAML>=3.11",
-    "web.py>=0.40.dev0",
+    "web.py==0.40",
     "lti>=0.9.0",
     "oauth2>=1.9.0.post1",
     "httplib2>=0.9",


### PR DESCRIPTION
# Description

UNCode does not work with last versions of web.py, thus we make sure web.py == 0.40
This bug was present when doing a new installation.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)