### PR TITLE
Small fix on multilang grader and plugins

### DIFF
--- a/inginious/frontend/plugins/grader_generator/pages/multilang_form.py
+++ b/inginious/frontend/plugins/grader_generator/pages/multilang_form.py
@@ -153,9 +153,12 @@ class MultilangForm(GraderForm):
                 pass
 
         for file in files_diff_for:
-            src = '{dir}{file}'.format(dir=self.task_fs.prefix, file=file)
-            dest = 'public/{}'.format(file)
+            src = os.path.join(self.task_fs.prefix, file)
+            public_dir = 'public/'
             try:
+                if not self.task_fs.exists(public_dir):
+                    os.mkdir(os.path.join(self.task_fs.prefix, public_dir))
+                dest = os.path.join(public_dir, file)
                 self.task_fs.copy_to(src, dest)
             except:
                 pass

--- a/inginious/frontend/plugins/problem_bank/index.html
+++ b/inginious/frontend/plugins/problem_bank/index.html
@@ -10,7 +10,9 @@ $def NavbarF():
         <li><a href="$get_homepath()/admin/$course.get_id()" title=$:_('"Administration"') data-toggle="tooltip"
                data-placement="bottom">
             <i class="fa fa-user-secret"></i></a></li>
-        <li class="active"><a href="#">$:_("Problem bank") <span class="sr-only">(current)</span></a></li>
+        <li class="active">
+            <a href="#">
+                <i class="fa fa-database"></i>  $:_("Problem bank")<span class="sr-only">(current)</span></a></li>
     </ol>
 
 $var Navbar: $:NavbarF()

--- a/inginious/frontend/plugins/statistics/pages/course_admin_statistics.html
+++ b/inginious/frontend/plugins/statistics/pages/course_admin_statistics.html
@@ -10,7 +10,11 @@ $def NavbarF():
         <li><a href="$get_homepath()/admin/$course.get_id()" title=$:_('"Administration"') data-toggle="tooltip"
                data-placement="bottom">
             <i class="fa fa-user-secret"></i></a></li>
-        <li class="active"><a href="#">$:_("Course statistics") <span class="sr-only">(current)</span></a></li>
+        <li class="active">
+            <a href="#">
+                <i class="fa fa-bar-chart"></i>  $:_("Course statistics") <span class="sr-only">(current)</span>
+            </a>
+        </li>
     </ol>
 
 $var Navbar: $:NavbarF()


### PR DESCRIPTION
# Description

- When a multilang task is saved, it did not correctly publish the input files (if checked) if `public/` directory was not present. This is fixed.
- In problem bank and course statistics fix the nav bar icon.

## Type of change
- [x] Bug fix

# How Has This Been Tested?

- [x] locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
