### PR TITLE
[Plagiarism] Use thread to generate check and update the document with a callback

### DIFF
--- a/inginious/frontend/plugins/plagiarism/pages/plagiarism.py
+++ b/inginious/frontend/plugins/plagiarism/pages/plagiarism.py
@@ -27,13 +27,14 @@ class PlagiarismPage(INGIniousAdminPage):
 
         plagiarism_checks = []
         for plagiarism_check in list(self.plagiarism_manager.get_all_plagiarism_checks_for_course(course_id)):
-            # TODO: 'container_name' is deprecated, when 'batch_jobs' collection is not longer used, update the code.
             if 'result' not in plagiarism_check:
                 status = 'waiting'
             elif plagiarism_check["result"]["retval"] == 0:
                 status = "ok"
             else:
                 status = 'ko'
+
+            # TODO: 'container_name' is deprecated, when 'batch_jobs' collection is not longer used, update the code.
             check = {
                 "task_name": plagiarism_check["container_name"] if 'container_name' in plagiarism_check else
                 plagiarism_check["task_name"],

--- a/inginious/frontend/plugins/plagiarism/pages/plagiarism.py
+++ b/inginious/frontend/plugins/plagiarism/pages/plagiarism.py
@@ -28,6 +28,12 @@ class PlagiarismPage(INGIniousAdminPage):
         plagiarism_checks = []
         for plagiarism_check in list(self.plagiarism_manager.get_all_plagiarism_checks_for_course(course_id)):
             # TODO: 'container_name' is deprecated, when 'batch_jobs' collection is not longer used, update the code.
+            if 'result' not in plagiarism_check:
+                status = 'waiting'
+            elif plagiarism_check["result"]["retval"] == 0:
+                status = "ok"
+            else:
+                status = 'ko'
             check = {
                 "task_name": plagiarism_check["container_name"] if 'container_name' in plagiarism_check else
                 plagiarism_check["task_name"],
@@ -35,7 +41,7 @@ class PlagiarismPage(INGIniousAdminPage):
                 "submitted_on": plagiarism_check["submitted_on"],
                 "language": AVAILABLE_PLAGIARISM_LANGUAGES[
                     plagiarism_check['language']] if 'language' in plagiarism_check else "Unknown",
-                "status": "ok" if plagiarism_check["result"]["retval"] == 0 else "ko"
+                "status": status
             }
 
             plagiarism_checks.append(check)

--- a/inginious/frontend/plugins/plagiarism/pages/templates/plagiarism.html
+++ b/inginious/frontend/plugins/plagiarism/pages/templates/plagiarism.html
@@ -41,27 +41,37 @@ $if plagiarism_checks:
                     <td>$check['language']</td>
                     <td>$check['submitted_on'].strftime("%d/%m/%Y %H:%M:%S")</td>
 
-                    $if check['status'] == 'ok':
-                        <td class="plagiarism-status-icon text-success" title="$:_('Results available')" data-toggle="tooltip" data-placement="bottom">
-                            <i class="fa fa-check"></i>
+                    $if check['status'] == 'waiting':
+                        <td class="plagiarism-status-icon text-warning" title="$:_('Waiting results')" data-toggle="tooltip" data-placement="bottom">
+                            <i class="fa fa-refresh fa-spin"></i>
+                        </td>
+                        <td>
+                            <a href="$get_homepath()/admin/$course.get_id()/plagiarism?drop=$check['id']" class="btn btn-danger btn-xs" title="$:_('Delete')"
+                                   data-toggle="tooltip" data-placement="bottom"
+                                   onclick="return confirm('Are you sure you want to delete this check?');"><i class="fa fa-remove fa-fw"></i></a>
                         </td>
                     $else:
-                        <td class="plagiarism-status-icon text-warning" title="$:_('Plagiarism finished with some errors')" data-toggle="tooltip" data-placement="bottom">
-                            <i class="fa fa-warning"></i>
+                        $if check['status'] == 'ok':
+                            <td class="plagiarism-status-icon text-success" title="$:_('Results available')" data-toggle="tooltip" data-placement="bottom">
+                                <i class="fa fa-check"></i>
+                            </td>
+                        $else:
+                            <td class="plagiarism-status-icon text-warning" title="$:_('Plagiarism finished with some errors')" data-toggle="tooltip" data-placement="bottom">
+                                <i class="fa fa-warning"></i>
+                            </td>
+                        <td>
+                            <div class="btn-group">
+                                <a href="$get_homepath()/admin/$course.get_id()/plagiarism/download/$check['id']/index.html" target="_blank" class="btn btn-success btn-xs" title="$:_('View results')"
+                                   data-toggle="tooltip" data-placement="bottom"><i class="fa fa-search fa-fw"></i></a>
+                                <a href="$get_homepath()/admin/$course.get_id()/plagiarism/summary/$check['id']" class="btn btn-primary btn-xs" title="$:_('See result files')"
+                                   data-toggle="tooltip" data-placement="bottom"><i class="fa fa-file fa-fw"></i></a>
+                                <a href="$get_homepath()/admin/$course.get_id()/plagiarism/download/$check['id']" class="btn btn-info btn-xs" title="$:_('Download results')"
+                                   data-toggle="tooltip" data-placement="bottom"><i class="fa fa-download fa-fw"></i></a>
+                                <a href="$get_homepath()/admin/$course.get_id()/plagiarism?drop=$check['id']" class="btn btn-danger btn-xs" title="$:_('Delete')"
+                                   data-toggle="tooltip" data-placement="bottom"
+                                   onclick="return confirm('Are you sure you want to delete this check?');"><i class="fa fa-remove fa-fw"></i></a>
+                            </div>
                         </td>
-                    <td>
-                        <div class="btn-group">
-                            <a href="$get_homepath()/admin/$course.get_id()/plagiarism/download/$check['id']/index.html" target="_blank" class="btn btn-success btn-xs" title="$:_('View results')"
-                               data-toggle="tooltip" data-placement="bottom"><i class="fa fa-search fa-fw"></i></a>
-                            <a href="$get_homepath()/admin/$course.get_id()/plagiarism/summary/$check['id']" class="btn btn-primary btn-xs" title="$:_('See result files')"
-                               data-toggle="tooltip" data-placement="bottom"><i class="fa fa-file fa-fw"></i></a>
-                            <a href="$get_homepath()/admin/$course.get_id()/plagiarism/download/$check['id']" class="btn btn-info btn-xs" title="$:_('Download results')"
-                               data-toggle="tooltip" data-placement="bottom"><i class="fa fa-download fa-fw"></i></a>
-                            <a href="$get_homepath()/admin/$course.get_id()/plagiarism?drop=$check['id']" class="btn btn-danger btn-xs" title="$:_('Delete')"
-                               data-toggle="tooltip" data-placement="bottom"
-                               onclick="return confirm('Are you sure you want to delete this check?');"><i class="fa fa-remove fa-fw"></i></a>
-                        </div>
-                    </td>
                 </tr>
         </table>
     </div>


### PR DESCRIPTION
# Description

Plagiarism check might take too long for many submissions and large code files, such as in notebook tasks. This causes in production that request is killed due to that process is done synchronously. The actual method that runs the plagiarism check is executed via a thread that updates the document in DB with the corresponding results when the process finishes via a callback.
Thus, when a check is created, it will display in main page that the process is running the waiting for results.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
-Locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
