### PR TITLE
Add minify_plugins utility rather than using a separate repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,7 @@ Follow this [tutorial/steps][development_url] on how to setup the development en
 
 ## Our Development Process
 
-We use github to host code, to track issues and feature requests, as well 
-as accept pull requests.
+We use github to host code, to track issues and feature requests, as well as accept pull requests.
 
 ## Your First Contribution
 
@@ -42,7 +41,9 @@ We actively welcome your pull requests.
 ### Code review
 
 UNCode team will check your pull request and one of us will be assigned to review it and
-leave feedback. Make to reply the given feedback ASAP.
+leave feedback. Make sure to reply the given feedback ASAP.
+
+Additionally, some mandatory checks are automatically done, make sure to pass them.
 
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, you will need to sign the Contributor License Agreement.

--- a/utils/minify_plugins/README.md
+++ b/utils/minify_plugins/README.md
@@ -1,0 +1,49 @@
+# Minify plugins
+
+This utility allows you to automatically minify css and js files for each plugin on UNCode.  
+
+## How to use
+
+All the code and logic is in the script `minify_plugins.js`. This uses [terser][terser_url] to minify JavaScript files,
+and for CSS files, [Clean CSS][clean_css_url] is used.
+
+### Minify new plugins
+
+In case a new plugin is added, you have to update the `minify_plugins.js` script, For that, a separate function is
+ created for each plugin, please see how this is done for the other plugins.
+
+### Run minifier 
+
+Before you start, you must install `node 8.x` or a greater version and `npm`.
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Update/create minified files for all plugins:
+
+```bash
+npm run minify
+```
+
+## Plugins
+
+The plugins being minified are:
+
+- UNCode.
+- UN template.
+- Statistics.
+- Register students.
+- Multilang.
+- Grader generator.
+- Custom input.
+- Code preview
+- Analytics
+- Plagiarism
+
+Some of this plugins, generate more than one minified file, for example, multilang.
+
+[terser_url]: https://github.com/terser/terser
+[clean_css_url]: https://www.cleancss.com/

--- a/utils/minify_plugins/README.md
+++ b/utils/minify_plugins/README.md
@@ -31,7 +31,6 @@ npm run minify
 ## Plugins
 
 The plugins being minified are:
-
 - UNCode.
 - UN template.
 - Statistics.

--- a/utils/minify_plugins/minify_plugins.js
+++ b/utils/minify_plugins/minify_plugins.js
@@ -1,0 +1,271 @@
+const fs = require('fs');
+const js_minifier = require("terser");
+const CleanCSS = require('clean-css');
+
+const _BASE_PATH = "../../inginious/frontend/plugins";
+const _UNCODE_PLUGIN_PATH = `${_BASE_PATH}/UNCode/static`;
+const _UN_TEMPLATE_PLUGIN_PATH = `${_BASE_PATH}/UN_template/static`;
+const _STATISTICS_PLUGIN_PATH = `${_BASE_PATH}/statistics/static`;
+const _REGISTER_STUDENTS_PLUGIN_PATH = `${_BASE_PATH}/register_students/static`;
+const _MULTILANG_PLUGIN_PATH = `${_BASE_PATH}/multilang/static`;
+const _GRADER_GENERATOR_PLUGIN_PATH = `${_BASE_PATH}/grader_generator/static`;
+const _CUSTOM_INPUT_PLUGIN_PATH = `${_BASE_PATH}/custom_input/static`;
+const _CODE_PREVIEW_PLUGIN_PATH = `${_BASE_PATH}/code_preview/static`;
+const _ANALYTICS_PLUGIN_PATH = `${_BASE_PATH}/analytics/static`;
+const _PLAGIARISM_PLUGIN_PATH = `${_BASE_PATH}/plagiarism/static`;
+
+/**
+ * Read file synchronously.
+ * @param file_name
+ * @returns String containing the read text.
+ */
+function read_file(file_name) {
+    return fs.readFileSync(file_name, "utf8");
+}
+
+/**
+ * Read all js files.
+ * @param js_files Array containing the path of every file.
+ * @returns Object where the key is the file path and value is a string with the read file.
+ */
+function read_js_files(js_files) {
+    let js_code = {};
+    js_files.forEach(file => {
+        js_code[file] = read_file(file)
+    });
+    return js_code;
+}
+
+/**
+ * Write file asynchronously with the minified text.
+ * @param file_name e.g /INGInious/inginious/frontend/plugins/UNCode/static/js/test.js
+ * @param data Minified text to be wrote in the file.
+ */
+function write_file(file_name, data) {
+    fs.writeFile(file_name, data, "utf8", (err) => {
+        if (err) {
+            console.log("There was an error creating file " + file_name);
+            return;
+        }
+        console.log('The file ' + file_name + ' has been saved!');
+    });
+}
+
+/**
+ * Generates the css minified file in `output_file_path` with the given name by `output_file_name`. The files
+ * specified in `css_files` are joint and then parsed.
+ * @param css_files: List of file names
+ * @param output_file_path: Path where the new file is created.
+ * @param output_file_name: Name for the new file (Without file extension).
+ */
+function minify_css_files(css_files, output_file_path, output_file_name) {
+    let result = new CleanCSS().minify(css_files);
+    if (result.errors.length) {
+        console.log("There were some errors while minifying css files: " + result.errors);
+    } else {
+        write_file(output_file_path + output_file_name + ".min.css", result.styles);
+    }
+}
+
+/**
+ * Generates the js minified file in `output_file_path` with the given name by `output_file_name`. The files
+ * specified in `js_files` are joint and then parsed.
+ * @param js_files: List of file names
+ * @param output_file_path: Path where the new file is created.
+ * @param output_file_name: Name for the new file (Without file extension).
+ */
+function minify_js_files(js_files, output_file_path, output_file_name) {
+    let js_code = read_js_files(js_files);
+    let result = js_minifier.minify(js_code);
+    if (result.error) {
+        console.log("There was an error minifying JS files. Check files name.");
+    } else {
+        write_file(output_file_path + output_file_name + ".min.js", result.code);
+    }
+}
+
+function get_css_file_path(file_path, name) {
+    return file_path + name + ".css";
+}
+
+function get_js_file_path(file_path, name) {
+    return file_path + name + ".js";
+}
+
+function minify_UNCode() {
+    const js_files_path = _UNCODE_PLUGIN_PATH + "/js/";
+    const css_files_path = _UNCODE_PLUGIN_PATH + "/css/";
+    const js_files = ["task_files_tab", "uncode"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+    const css_files = ["uncode"].map(name => {
+        return get_css_file_path(css_files_path, name)
+    });
+
+    console.log("Minify 'UNCode' static files.");
+
+    minify_js_files(js_files, js_files_path, "UNCode");
+
+    minify_css_files(css_files, css_files_path, "UNCode");
+}
+
+function minify_UN_Template() {
+    const js_files_path = _UN_TEMPLATE_PLUGIN_PATH + "/js/";
+    const css_files_path = _UN_TEMPLATE_PLUGIN_PATH + "/css/";
+    const js_files = ["unal"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+    const css_files = ["reset", "unal", "base", "tablet", "phone", "small", "printer", "new_unal"].map(name => {
+        return get_css_file_path(css_files_path, name)
+    });
+
+    console.log("Minify 'UN_template' static files.");
+
+    minify_js_files(js_files, js_files_path, "unal");
+
+    minify_css_files(css_files, css_files_path, "UN_template");
+}
+
+function minify_statistics() {
+    const js_files_path = _STATISTICS_PLUGIN_PATH + "/js/";
+    const css_files_path = _STATISTICS_PLUGIN_PATH + "/css/";
+    const css_files = ["statistics"].map(name => {
+        return get_css_file_path(css_files_path, name)
+    });
+
+    console.log("Minify 'statistics' static files.");
+
+    minify_css_files(css_files, css_files_path, "statistics");
+
+    let js_files = ["statistics", "course_admin_statistics"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+    minify_js_files(js_files, js_files_path, "course_admin_statistics");
+
+    js_files = ["statistics", "user_statistics"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+    minify_js_files(js_files, js_files_path, "user_statistics");
+}
+
+function minify_register_students() {
+    const js_files_path = _REGISTER_STUDENTS_PLUGIN_PATH + "/js/";
+    const css_files_path = _REGISTER_STUDENTS_PLUGIN_PATH + "/css/";
+    const js_files = ["register"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+    const css_files = ["register_students"].map(name => {
+        return get_css_file_path(css_files_path, name)
+    });
+
+    console.log("Minify 'register_students' static files.");
+
+    minify_js_files(js_files, js_files_path, "register");
+
+    minify_css_files(css_files, css_files_path, "register_students");
+}
+
+function minify_multilang() {
+    const js_files_path = _MULTILANG_PLUGIN_PATH + "/";
+    const css_files_path = _MULTILANG_PLUGIN_PATH + "/";
+
+    console.log("Minify 'multilang' static files.");
+
+    let js_files = ["pythonTutor", "codemirror_linter", "lint"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+    minify_js_files(js_files, js_files_path, "tools");
+
+    js_files = ["multilang", "grader"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+    minify_js_files(js_files, js_files_path, "multilang");
+
+    js_files = ["hdlgrader"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+    minify_js_files(js_files, js_files_path, "hdlgrader");
+
+    let css_files = ["lint"].map(name => {
+        return get_css_file_path(css_files_path, name)
+    });
+    minify_css_files(css_files, css_files_path, "tools");
+
+    css_files = ["multilang"].map(name => {
+        return get_css_file_path(css_files_path, name)
+    });
+    minify_css_files(css_files, css_files_path, "multilang");
+}
+
+function minify_grader_generator() {
+    const js_files_path = _GRADER_GENERATOR_PLUGIN_PATH + "/js/";
+    const js_files = ["grader_generator", "notebook_grader_generator"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+
+    console.log("Minify 'grader_generator' static files.");
+
+    minify_js_files(js_files, js_files_path, "grader_generator");
+}
+
+function minify_custom_input() {
+    const js_files_path = _CUSTOM_INPUT_PLUGIN_PATH + "/";
+    const js_files = ["custom_input"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+
+    console.log("Minify 'custom_input' static files.");
+
+    minify_js_files(js_files, js_files_path, "custom_input");
+}
+
+function minify_code_preview() {
+    const js_files_path = _CODE_PREVIEW_PLUGIN_PATH + "/js/";
+    const js_files = ["code_preview_load"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+
+    console.log("Minify 'code_preview' static files.");
+
+    minify_js_files(js_files, js_files_path, "code_preview_load")
+}
+
+function minify_analytics() {
+    const js_files_path = _ANALYTICS_PLUGIN_PATH + "/js/";
+    const css_files_path = _ANALYTICS_PLUGIN_PATH + "/css/";
+    const js_files = ["analytics", "box_plot", "calendar_view", "radar", "time_series"].map(name => {
+        return get_js_file_path(js_files_path, name)
+    });
+
+    const css_files = ["analytics"].map(name => {
+        return get_css_file_path(css_files_path, name)
+    });
+
+    console.log("Minify 'analytics' static files.");
+
+    minify_js_files(js_files, js_files_path, "analytics");
+    minify_css_files(css_files, css_files_path, "analytics");
+}
+
+function minify_plagiarism() {
+    const css_files_path = _PLAGIARISM_PLUGIN_PATH + "/css/";
+
+    const css_files = ["plagiarism"].map(name => {
+        return get_css_file_path(css_files_path, name)
+    });
+
+    console.log("Minify 'plagiarism' static files.");
+
+    minify_css_files(css_files, css_files_path, "plagiarism");
+}
+
+minify_UNCode();
+minify_UN_Template();
+minify_statistics();
+minify_register_students();
+minify_multilang();
+minify_grader_generator();
+minify_custom_input();
+minify_code_preview();
+minify_analytics();
+minify_plagiarism();

--- a/utils/minify_plugins/minify_plugins.js
+++ b/utils/minify_plugins/minify_plugins.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const js_minifier = require("terser");
-const CleanCSS = require('clean-css');
+const fs = require("fs");
+const jsMinifier = require("terser");
+const CleanCSS = require("clean-css");
 
 const _BASE_PATH = "../../inginious/frontend/plugins";
 const _UNCODE_PLUGIN_PATH = `${_BASE_PATH}/UNCode/static`;
@@ -16,256 +16,256 @@ const _PLAGIARISM_PLUGIN_PATH = `${_BASE_PATH}/plagiarism/static`;
 
 /**
  * Read file synchronously.
- * @param file_name
+ * @param fileName
  * @returns String containing the read text.
  */
-function read_file(file_name) {
-    return fs.readFileSync(file_name, "utf8");
+function readFile(fileName) {
+    return fs.readFileSync(fileName, "utf8");
 }
 
 /**
  * Read all js files.
- * @param js_files Array containing the path of every file.
+ * @param jsFiles Array containing the path of every file.
  * @returns Object where the key is the file path and value is a string with the read file.
  */
-function read_js_files(js_files) {
-    let js_code = {};
-    js_files.forEach(file => {
-        js_code[file] = read_file(file)
+function readJSFiles(jsFiles) {
+    const jsCode = {};
+    jsFiles.forEach((file) => {
+        jsCode[file] = readFile(file);
     });
-    return js_code;
+    return jsCode;
 }
 
 /**
  * Write file asynchronously with the minified text.
- * @param file_name e.g /INGInious/inginious/frontend/plugins/UNCode/static/js/test.js
+ * @param fileName e.g /INGInious/inginious/frontend/plugins/UNCode/static/js/test.js
  * @param data Minified text to be wrote in the file.
  */
-function write_file(file_name, data) {
-    fs.writeFile(file_name, data, "utf8", (err) => {
+function writeFile(fileName, data) {
+    fs.writeFile(fileName, data, "utf8", (err) => {
         if (err) {
-            console.log("There was an error creating file " + file_name);
+            console.log("There was an error creating file " + fileName);
             return;
         }
-        console.log('The file ' + file_name + ' has been saved!');
+        console.log(`The file ${fileName} has been saved!`);
     });
 }
 
 /**
- * Generates the css minified file in `output_file_path` with the given name by `output_file_name`. The files
- * specified in `css_files` are joint and then parsed.
- * @param css_files: List of file names
- * @param output_file_path: Path where the new file is created.
- * @param output_file_name: Name for the new file (Without file extension).
+ * Generates the css minified file in `outputFilePath` with the given name by `outputFileName`. The files
+ * specified in `cssFiles` are joint and then parsed.
+ * @param cssFiles: List of file names
+ * @param outputFilePath: Path where the new file is created.
+ * @param outputFileName: Name for the new file (Without file extension).
  */
-function minify_css_files(css_files, output_file_path, output_file_name) {
-    let result = new CleanCSS().minify(css_files);
+function minifyCssFiles(cssFiles, outputFilePath, outputFileName) {
+    const result = new CleanCSS().minify(cssFiles);
     if (result.errors.length) {
         console.log("There were some errors while minifying css files: " + result.errors);
     } else {
-        write_file(output_file_path + output_file_name + ".min.css", result.styles);
+        writeFile(outputFilePath + outputFileName + ".min.css", result.styles);
     }
 }
 
 /**
- * Generates the js minified file in `output_file_path` with the given name by `output_file_name`. The files
- * specified in `js_files` are joint and then parsed.
- * @param js_files: List of file names
- * @param output_file_path: Path where the new file is created.
- * @param output_file_name: Name for the new file (Without file extension).
+ * Generates the js minified file in `outputFilePath` with the given name by `outputFileName`. The files
+ * specified in `jsFiles` are joint and then parsed.
+ * @param jsFiles: List of file names
+ * @param outputFilePath: Path where the new file is created.
+ * @param outputFileName: Name for the new file (Without file extension).
  */
-function minify_js_files(js_files, output_file_path, output_file_name) {
-    let js_code = read_js_files(js_files);
-    let result = js_minifier.minify(js_code);
+function minifyJSFiles(jsFiles, outputFilePath, outputFileName) {
+    const jsCode = readJSFiles(jsFiles);
+    const result = jsMinifier.minify(jsCode);
     if (result.error) {
         console.log("There was an error minifying JS files. Check files name.");
     } else {
-        write_file(output_file_path + output_file_name + ".min.js", result.code);
+        writeFile(outputFilePath + outputFileName + ".min.js", result.code);
     }
 }
 
-function get_css_file_path(file_path, name) {
-    return file_path + name + ".css";
+function getCssFilePath(filePath, name) {
+    return filePath + name + ".css";
 }
 
-function get_js_file_path(file_path, name) {
-    return file_path + name + ".js";
+function getJSFilePath(filePath, name) {
+    return filePath + name + ".js";
 }
 
-function minify_UNCode() {
-    const js_files_path = _UNCODE_PLUGIN_PATH + "/js/";
-    const css_files_path = _UNCODE_PLUGIN_PATH + "/css/";
-    const js_files = ["task_files_tab", "uncode"].map(name => {
-        return get_js_file_path(js_files_path, name)
+function minifyUNCodePlugin() {
+    const jsFilesPath = _UNCODE_PLUGIN_PATH + "/js/";
+    const cssFilesPath = _UNCODE_PLUGIN_PATH + "/css/";
+    const jsFiles = ["task_files_tab", "uncode"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
-    const css_files = ["uncode"].map(name => {
-        return get_css_file_path(css_files_path, name)
+    const cssFiles = ["uncode"].map((name) => {
+        return getCssFilePath(cssFilesPath, name);
     });
 
     console.log("Minify 'UNCode' static files.");
 
-    minify_js_files(js_files, js_files_path, "UNCode");
+    minifyJSFiles(jsFiles, jsFilesPath, "UNCode");
 
-    minify_css_files(css_files, css_files_path, "UNCode");
+    minifyCssFiles(cssFiles, cssFilesPath, "UNCode");
 }
 
-function minify_UN_Template() {
-    const js_files_path = _UN_TEMPLATE_PLUGIN_PATH + "/js/";
-    const css_files_path = _UN_TEMPLATE_PLUGIN_PATH + "/css/";
-    const js_files = ["unal"].map(name => {
-        return get_js_file_path(js_files_path, name)
+function minifyUNTemplatePlugin() {
+    const jsFilesPath = _UN_TEMPLATE_PLUGIN_PATH + "/js/";
+    const cssFilesPath = _UN_TEMPLATE_PLUGIN_PATH + "/css/";
+    const jsFiles = ["unal"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
-    const css_files = ["reset", "unal", "base", "tablet", "phone", "small", "printer", "new_unal"].map(name => {
-        return get_css_file_path(css_files_path, name)
+    const cssFiles = ["reset", "unal", "base", "tablet", "phone", "small", "printer", "new_unal"].map((name) => {
+        return getCssFilePath(cssFilesPath, name);
     });
 
     console.log("Minify 'UN_template' static files.");
 
-    minify_js_files(js_files, js_files_path, "unal");
+    minifyJSFiles(jsFiles, jsFilesPath, "unal");
 
-    minify_css_files(css_files, css_files_path, "UN_template");
+    minifyCssFiles(cssFiles, cssFilesPath, "UN_template");
 }
 
-function minify_statistics() {
-    const js_files_path = _STATISTICS_PLUGIN_PATH + "/js/";
-    const css_files_path = _STATISTICS_PLUGIN_PATH + "/css/";
-    const css_files = ["statistics"].map(name => {
-        return get_css_file_path(css_files_path, name)
+function minifyStatisticsPlugin() {
+    const jsFilesPath = _STATISTICS_PLUGIN_PATH + "/js/";
+    const cssFilesPath = _STATISTICS_PLUGIN_PATH + "/css/";
+    const cssFiles = ["statistics"].map((name) => {
+        return getCssFilePath(cssFilesPath, name);
     });
 
     console.log("Minify 'statistics' static files.");
 
-    minify_css_files(css_files, css_files_path, "statistics");
+    minifyCssFiles(cssFiles, cssFilesPath, "statistics");
 
-    let js_files = ["statistics", "course_admin_statistics"].map(name => {
-        return get_js_file_path(js_files_path, name)
+    let jsFiles = ["statistics", "course_admin_statistics"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
-    minify_js_files(js_files, js_files_path, "course_admin_statistics");
+    minifyJSFiles(jsFiles, jsFilesPath, "course_admin_statistics");
 
-    js_files = ["statistics", "user_statistics"].map(name => {
-        return get_js_file_path(js_files_path, name)
+    jsFiles = ["statistics", "user_statistics"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
-    minify_js_files(js_files, js_files_path, "user_statistics");
+    minifyJSFiles(jsFiles, jsFilesPath, "user_statistics");
 }
 
-function minify_register_students() {
-    const js_files_path = _REGISTER_STUDENTS_PLUGIN_PATH + "/js/";
-    const css_files_path = _REGISTER_STUDENTS_PLUGIN_PATH + "/css/";
-    const js_files = ["register"].map(name => {
-        return get_js_file_path(js_files_path, name)
+function minifyRegisterStudentsPlugin() {
+    const jsFilesPath = _REGISTER_STUDENTS_PLUGIN_PATH + "/js/";
+    const cssFilesPath = _REGISTER_STUDENTS_PLUGIN_PATH + "/css/";
+    const jsFiles = ["register"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
-    const css_files = ["register_students"].map(name => {
-        return get_css_file_path(css_files_path, name)
+    const cssFiles = ["register_students"].map((name) => {
+        return getCssFilePath(cssFilesPath, name);
     });
 
     console.log("Minify 'register_students' static files.");
 
-    minify_js_files(js_files, js_files_path, "register");
+    minifyJSFiles(jsFiles, jsFilesPath, "register");
 
-    minify_css_files(css_files, css_files_path, "register_students");
+    minifyCssFiles(cssFiles, cssFilesPath, "register_students");
 }
 
-function minify_multilang() {
-    const js_files_path = _MULTILANG_PLUGIN_PATH + "/";
-    const css_files_path = _MULTILANG_PLUGIN_PATH + "/";
+function minifyMultilangPlugin() {
+    const jsFilesPath = _MULTILANG_PLUGIN_PATH + "/";
+    const cssFilesPath = _MULTILANG_PLUGIN_PATH + "/";
 
     console.log("Minify 'multilang' static files.");
 
-    let js_files = ["pythonTutor", "codemirror_linter", "lint"].map(name => {
-        return get_js_file_path(js_files_path, name)
+    let jsFiles = ["pythonTutor", "codemirror_linter", "lint"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
-    minify_js_files(js_files, js_files_path, "tools");
+    minifyJSFiles(jsFiles, jsFilesPath, "tools");
 
-    js_files = ["multilang", "grader"].map(name => {
-        return get_js_file_path(js_files_path, name)
+    jsFiles = ["multilang", "grader"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
-    minify_js_files(js_files, js_files_path, "multilang");
+    minifyJSFiles(jsFiles, jsFilesPath, "multilang");
 
-    js_files = ["hdlgrader"].map(name => {
-        return get_js_file_path(js_files_path, name)
+    jsFiles = ["hdlgrader"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
-    minify_js_files(js_files, js_files_path, "hdlgrader");
+    minifyJSFiles(jsFiles, jsFilesPath, "hdlgrader");
 
-    let css_files = ["lint"].map(name => {
-        return get_css_file_path(css_files_path, name)
+    let cssFiles = ["lint"].map((name) => {
+        return getCssFilePath(cssFilesPath, name);
     });
-    minify_css_files(css_files, css_files_path, "tools");
+    minifyCssFiles(cssFiles, cssFilesPath, "tools");
 
-    css_files = ["multilang"].map(name => {
-        return get_css_file_path(css_files_path, name)
+    cssFiles = ["multilang"].map((name) => {
+        return getCssFilePath(cssFilesPath, name);
     });
-    minify_css_files(css_files, css_files_path, "multilang");
+    minifyCssFiles(cssFiles, cssFilesPath, "multilang");
 }
 
-function minify_grader_generator() {
-    const js_files_path = _GRADER_GENERATOR_PLUGIN_PATH + "/js/";
-    const js_files = ["grader_generator", "notebook_grader_generator"].map(name => {
-        return get_js_file_path(js_files_path, name)
+function minifyGraderGeneratorPlugin() {
+    const jsFilesPath = _GRADER_GENERATOR_PLUGIN_PATH + "/js/";
+    const jsFiles = ["grader_generator", "notebook_grader_generator"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
 
     console.log("Minify 'grader_generator' static files.");
 
-    minify_js_files(js_files, js_files_path, "grader_generator");
+    minifyJSFiles(jsFiles, jsFilesPath, "grader_generator");
 }
 
-function minify_custom_input() {
-    const js_files_path = _CUSTOM_INPUT_PLUGIN_PATH + "/";
-    const js_files = ["custom_input"].map(name => {
-        return get_js_file_path(js_files_path, name)
+function minifyCustomInputPlugin() {
+    const jsFilesPath = _CUSTOM_INPUT_PLUGIN_PATH + "/";
+    const jsFiles = ["custom_input"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
 
     console.log("Minify 'custom_input' static files.");
 
-    minify_js_files(js_files, js_files_path, "custom_input");
+    minifyJSFiles(jsFiles, jsFilesPath, "custom_input");
 }
 
-function minify_code_preview() {
-    const js_files_path = _CODE_PREVIEW_PLUGIN_PATH + "/js/";
-    const js_files = ["code_preview_load"].map(name => {
-        return get_js_file_path(js_files_path, name)
+function minifyCodePreviewPlugin() {
+    const jsFilesPath = _CODE_PREVIEW_PLUGIN_PATH + "/js/";
+    const jsFiles = ["code_preview_load"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
 
     console.log("Minify 'code_preview' static files.");
 
-    minify_js_files(js_files, js_files_path, "code_preview_load")
+    minifyJSFiles(jsFiles, jsFilesPath, "code_preview_load");
 }
 
-function minify_analytics() {
-    const js_files_path = _ANALYTICS_PLUGIN_PATH + "/js/";
-    const css_files_path = _ANALYTICS_PLUGIN_PATH + "/css/";
-    const js_files = ["analytics", "box_plot", "calendar_view", "radar", "time_series"].map(name => {
-        return get_js_file_path(js_files_path, name)
+function minifyAnalyticsPlugin() {
+    const jsFilesPath = _ANALYTICS_PLUGIN_PATH + "/js/";
+    const cssFilesPath = _ANALYTICS_PLUGIN_PATH + "/css/";
+    const jsFiles = ["analytics", "box_plot", "calendar_view", "radar", "time_series"].map((name) => {
+        return getJSFilePath(jsFilesPath, name);
     });
 
-    const css_files = ["analytics"].map(name => {
-        return get_css_file_path(css_files_path, name)
+    const cssFiles = ["analytics"].map((name) => {
+        return getCssFilePath(cssFilesPath, name);
     });
 
     console.log("Minify 'analytics' static files.");
 
-    minify_js_files(js_files, js_files_path, "analytics");
-    minify_css_files(css_files, css_files_path, "analytics");
+    minifyJSFiles(jsFiles, jsFilesPath, "analytics");
+    minifyCssFiles(cssFiles, cssFilesPath, "analytics");
 }
 
-function minify_plagiarism() {
-    const css_files_path = _PLAGIARISM_PLUGIN_PATH + "/css/";
+function minifyPlagiarismPlugin() {
+    const cssFilesPath = _PLAGIARISM_PLUGIN_PATH + "/css/";
 
-    const css_files = ["plagiarism"].map(name => {
-        return get_css_file_path(css_files_path, name)
+    const cssFiles = ["plagiarism"].map((name) => {
+        return getCssFilePath(cssFilesPath, name);
     });
 
     console.log("Minify 'plagiarism' static files.");
 
-    minify_css_files(css_files, css_files_path, "plagiarism");
+    minifyCssFiles(cssFiles, cssFilesPath, "plagiarism");
 }
 
-minify_UNCode();
-minify_UN_Template();
-minify_statistics();
-minify_register_students();
-minify_multilang();
-minify_grader_generator();
-minify_custom_input();
-minify_code_preview();
-minify_analytics();
-minify_plagiarism();
+minifyUNCodePlugin();
+minifyUNTemplatePlugin();
+minifyStatisticsPlugin();
+minifyRegisterStudentsPlugin();
+minifyMultilangPlugin();
+minifyGraderGeneratorPlugin();
+minifyCustomInputPlugin();
+minifyCodePreviewPlugin();
+minifyAnalyticsPlugin();
+minifyPlagiarismPlugin();

--- a/utils/minify_plugins/package-lock.json
+++ b/utils/minify_plugins/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "minify_plugins",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "clean-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+    },
+    "css-tree": {
+      "version": "1.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+      "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+      "requires": {
+        "mdn-data": "~1.1.0",
+        "source-map": "^0.5.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "csso": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+      "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+      "requires": {
+        "css-tree": "1.0.0-alpha.29"
+      }
+    },
+    "mdn-data": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "terser": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "requires": {
+        "commander": "^2.19.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.10"
+      }
+    }
+  }
+}

--- a/utils/minify_plugins/package.json
+++ b/utils/minify_plugins/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "minify_plugins",
+  "version": "1.0.0",
+  "description": "Program to minify automatically the static files on plugins",
+  "main": "minify_plugins.js",
+  "scripts": {
+    "minify": "node ./minify_plugins.js"
+  },
+  "author": "UNCode",
+  "license": "GNU AGPL v3",
+  "dependencies": {
+    "csso": "^3.5.1",
+    "terser": "^3.17.0"
+  },
+  "devDependencies": {
+    "clean-css": "^4.2.1"
+  }
+}


### PR DESCRIPTION
# Description

This adds the utility to minify static files in plugins rather than having the code in a separate repository (https://github.com/JuezUN/Minify-static-files). This eases the developer's workflow.

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
