### PR TITLE
Fix on Custom input

### DIFF
--- a/inginious/frontend/plugins/custom_input/__init__.py
+++ b/inginious/frontend/plugins/custom_input/__init__.py
@@ -57,7 +57,7 @@ def customInputManagerWithCurriedClient(client):
                 }
                 user_input = task.adapt_input_for_backend(web.input(**init_var))
                 for key, value in user_input.items():
-                    if type(value) == 'str':
+                    if type(value) is str:
                         user_input[key] = user_input[key].replace("\r", "")
                 result, grade, problems, tests, custom, archive, stdout, stderr = self.add_unsaved_job(task, user_input)
 


### PR DESCRIPTION
# Description

String instance check was incorrect, this caused that custom input takes the character for each line `\r`. This fixes here.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
