### PR TITLE
Do not show all submission data

### DIFF
--- a/inginious/frontend/pages/course_admin/submission.py
+++ b/inginious/frontend/pages/course_admin/submission.py
@@ -68,12 +68,4 @@ class SubmissionPage(INGIniousAdminPage):
             } for problem in task.get_problems()
         }
 
-        to_display.update({
-            pid: {
-                "id": pid,
-                "name": pid,
-                "defined": False
-            } for pid in (set(submission["input"]) - set(to_display))
-        })
-
         return self.template_helper.get_renderer().course_admin.submission(course, task, submission, to_display.values())


### PR DESCRIPTION
# Description

When a single submission is seen, it shows several data that is irrelevant and is internal, it is only necessary to show the subproblems.

Fixes #247 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
