### PR TITLE
Add proxy fix to get proxy ENV vars from docker in base container

### DIFF
--- a/base-containers/base/Dockerfile
+++ b/base-containers/base/Dockerfile
@@ -37,4 +37,7 @@ RUN     groupadd --gid 4242 worker && \
 RUN     echo -e "export LANG=en_US.UTF-8\nexport LANGUAGE=en_US:en\nexport LC_ALL=en_US.UTF-8\n" > /etc/profile
 RUN     sed -i.bak '/^AcceptEnv/ d' /etc/ssh/sshd_config
 
+# Set proxy vars in case the agent is behind a proxy
+RUN     echo -e "export http_proxy=\"$http_proxy\"\nexport https_proxy=\"$http_proxy\"\nexport HTTP_PROXY=\"$http_proxy\"\nexport HTTPS_PROXY=\"$http_proxy\"\n" >> /etc/profile
+
 CMD ["INGInious"]


### PR DESCRIPTION
# Description

In case a container is running behind a proxy, the env variables for the proxy were not shared for all users in the container, thus, a line in base container Dockerfile is added to append these variables in `/etc/profile`, and that way all the users will have access to these variables in case there is a proxy.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
