### PR TITLE
Limit run_student container to use max 1 CPU

### DIFF
--- a/inginious/agent/docker_agent/_docker_interface.py
+++ b/inginious/agent/docker_agent/_docker_interface.py
@@ -121,6 +121,7 @@ class DockerInterface(object):  # pragma: no cover
             mem_limit=str(mem_limit) + "M",
             memswap_limit=str(mem_limit) + "M",
             mem_swappiness=0,
+            cpu_quota=100000,
             oom_kill_disable=True,
             network_mode=('none' if not network_grading else ('container:' + parent_container_id)),
             volumes={


### PR DESCRIPTION
# Description

Notebooks submissions usually use more than 1 CPU when `ok` is running. Probably `ok` uses some kind of threading to speed grading up. However, to optimize resources, only one container can use up to 1 CPU in the server to avoid that the OS sleeps some process. Thus, a small change is done to allow 1 CPU per `run_student` container. That way, the submissions do not get unexpected TIME LIMITs

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Load testing was done to figure out whether this change fixes the problem or not. Effectively, this is solved, and now a container is using up to 1 CPU, and submissions do not get TIME LIMIT EXCEEDED when they are not expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
