### PR TITLE
Add language in custom input

### DIFF
--- a/inginious/frontend/plugins/multilang/problems/custom_input.py
+++ b/inginious/frontend/plugins/multilang/problems/custom_input.py
@@ -21,6 +21,9 @@ def custom_input_manager_multilang(client):
 
         def add_unsaved_job(self, task, inputdata):
             temp_client = ClientSync(self._client)
+
+            # Send the session language to the container to do the corresponding translations.
+            inputdata["@lang"] = self.user_manager.session_language()
             return temp_client.new_job(task, inputdata, "Custom input - " + self.user_manager.session_username())
 
         def API_POST(self):

--- a/inginious/frontend/plugins/multilang/problems/custom_test_manager.py
+++ b/inginious/frontend/plugins/multilang/problems/custom_test_manager.py
@@ -66,6 +66,9 @@ class CustomTestManager(object):
             else:
                 raise Exception(_("A custom test is already pending for this task. Wait for a while to run the tests."))
 
+        # Send the session language to the container to do the corresponding translations.
+        input_data["@lang"] = self._user_manager.session_language()
+
         job_id = self._client.new_job(task, input_data,
                                       (lambda result, grade, problems, tests, custom, archive, stdout, stderr:
                                        self._job_done_callback(custom_test_id, result, stdout, stderr)),


### PR DESCRIPTION
# Description

In order to translate messages in the containers ([INGInious-containers#60](https://github.com/JuezUN/INGInious-containers/issues/60)), it is necessary to send the parameter `@lang` in custom input for multilang and notebook to the containers as it was not done before.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
