### PR TITLE
Changed the linter option in course settings when LTI is enabled in course

### DIFF
--- a/inginious/frontend/templates/course_admin/settings.html
+++ b/inginious/frontend/templates/course_admin/settings.html
@@ -107,7 +107,7 @@ $elif saved:
             </label>
         </div>
     </div>
-    <div class="form-group no-lti">
+    <div class="form-group">
         <label class="col-sm-2 control-label">$:_("Use Linter in tasks automatically")</label>
         <div class="col-sm-10">
             <label>


### PR DESCRIPTION
# Description

This is a small change to see the 'Use Linter in task automatically' option when LTI is enabled in the course.

# How Has This Been Tested?

It was tested using the 'Enable LTI' option, and by checking that the 'Use Linter in tasks automatically' option was displayed.
