### PR TITLE
Hotfix on Multilang Code file subproblem

### DIFF
--- a/inginious/frontend/plugins/multilang/problems/code_multiple_file_languages_problem.py
+++ b/inginious/frontend/plugins/multilang/problems/code_multiple_file_languages_problem.py
@@ -43,7 +43,7 @@ class DisplayableCodeFileMultipleLanguagesProblem(CodeFileMultipleLanguagesProbl
         return renderer.file_multilang_edit(key, get_all_available_languages())
 
     def show_input(self, template_helper, language, seed):
-        allowed_languages = {language: get_all_available_languages()[language] for language in self._languages}
+        allowed_languages = { language : get_all_available_languages()[language] for language in self._languages if language in get_all_available_languages() }
         allowed_languages = OrderedDict([(lang, allowed_languages[lang]) for lang in sorted(allowed_languages.keys())])
         dropdown_id = self.get_id() + "/language"
         custom_input_id = self.get_id() + "/input"


### PR DESCRIPTION
# Description

This solves an error on old code file multilang tasks that have saved on their task.yaml file the language Java 7 that recently was disabled. The error is a KeyError, on show_input() func, a dict is created by comprehension and the get_all_available_languages() function is called and return a dict with the languages on languages.py file, but with that dict is created the new one getting the values with the list of the languages of task.yaml file like keys. The error is solved by verifying that the key exist on the dict returned by get_all_available_languages()

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on my local development environment displaying tasks with the value Java 7 on the languages on the task.yaml file

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code