### PR TITLE
Ordered dict with test cases on notebook

### DIFF
--- a/inginious/frontend/parsable_text.py
+++ b/inginious/frontend/parsable_text.py
@@ -9,7 +9,7 @@ import json
 from enum import IntEnum
 import gettext
 from datetime import datetime
-
+import collections
 import tidylib
 from docutils import core, nodes, utils
 from docutils.parsers.rst import directives, Directive
@@ -372,7 +372,8 @@ class ParsableText(object):
             if test_custom_feedback:
                 template_info['custom_feedback'] = test_custom_feedback
                 result_html.append(test_custom_feedback_template_html)
-            for i, case_debug_info in cases_debug_info.items():
+            cases_debug_info_sorted = collections.OrderedDict(sorted(cases_debug_info.items()))
+            for i, case_debug_info in cases_debug_info_sorted.items():
                 debug_info = []
                 if case_debug_info["is_runtime_error"]:
                     debug_info.append(test_case_error_template_html.format(case_error=case_debug_info["error"]).


### PR DESCRIPTION
# Description

This is a small fix that sort the test cases of each test. The error was fixed on this repo because it was reproduced with the response_type field set on json, in that case the feedback is parsed here and the test cases are parsed with the object view generated by the method dict.items(), this object by default is sorted in python3.6+ but this webapp is running on 3.5, so we add the logic to convert the dict to an OrderedDict.

Fixes #469 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was tested on my own development environment, making submissions with errors like this
![image](https://user-images.githubusercontent.com/36159478/192658623-6afac614-f159-4311-addb-7d817e7d4640.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

