### PR TITLE
Bug on docker agent, exception handling on watcher

### DIFF
--- a/inginious/agent/docker_agent/__init__.py
+++ b/inginious/agent/docker_agent/__init__.py
@@ -131,7 +131,8 @@ class DockerAgent(Agent):
                     except:
                         self._logger.exception("Cannot parse exitCode for container %s", container_id)
                         retval = -1
-                    stdout, stderr = await self._docker.get_logs(container_id)
+                    #UNCOMMENT TO SEE DEBUG LOGS
+                    #stdout, stderr = await self._docker.get_logs(container_id)
                     
                     if container_id in self._containers_running:
                         #UNCOMMENT TO SEE DEBUG LOGS FOR GRADING CONTAINERS
@@ -643,10 +644,10 @@ class DockerAgent(Agent):
     async def run(self):
         await self._init_clean()
 
-        # Init Docker events watcher
-        watcher_docker_event = self._create_safe_task(self._watch_docker_events())
-
         try:
+            # Init Docker events watcher
+            watcher_docker_event = self._create_safe_task(self._watch_docker_events())
+            
             await super(DockerAgent, self).run()
         except:
             await self._end_clean()

--- a/inginious/agent/docker_agent/_docker_interface.py
+++ b/inginious/agent/docker_agent/_docker_interface.py
@@ -151,8 +151,12 @@ class DockerInterface(object):  # pragma: no cover
 
     def get_logs(self, container_id):
         """ Return the full stdout/stderr of a container"""
-        stdout = self._docker.containers.get(container_id).logs(stdout=True, stderr=False).decode('utf8')
-        stderr = self._docker.containers.get(container_id).logs(stdout=False, stderr=True).decode('utf8')
+        try:
+            stdout = self._docker.containers.get(container_id).logs(stdout=True, stderr=False).decode('utf8')
+            stderr = self._docker.containers.get(container_id).logs(stdout=False, stderr=True).decode('utf8')
+        except Exception as e:
+            stdout = ""
+            stderr = "Container not found, error:\n" + str(e)
         return stdout, stderr
 
     def get_stats(self, container_id):


### PR DESCRIPTION
# Description

This is a small PR with 3 changes, first line 135 in docker agent init file on _watch_docker_events method was commented, this was raising an exception on the async method, this line is necessary only for debugging purposes, the second change is ensure in the run method of the docker agent that if an exception is raised with the watcher, end clean the process in order to restart the agent correctly. And only if the exception is not caught with the previous changes, a try except clause was added in the method get_logs on docker_interface. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was tested on my own development environment, but the bug is difficult to reproduce

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

