### PR TITLE
Remove extensions not supported on project tasks

### DIFF
--- a/inginious/frontend/app.py
+++ b/inginious/frontend/app.py
@@ -99,7 +99,7 @@ def _put_configuration_defaults(config):
     :return: the same dict, but with defaults for some unfilled parameters
     """
     if 'allowed_file_extensions' not in config:
-        config['allowed_file_extensions'] = [".c", ".cpp", ".java", ".oz", ".zip", ".tar.gz", ".tar.bz2", ".txt"]
+        config['allowed_file_extensions'] = [".zip", ".tar.gz", ".tar.bz2"]
     if 'max_file_size' not in config:
         config['max_file_size'] = 1024 * 1024
     return config


### PR DESCRIPTION
# Description

This PR remove the old extensions that are not supported on multilang project tasks, this in order to be consistent with the logic of the container.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was tested on my own develop environment, displaying project multilang tasks 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

