### PR TITLE
Fix textdistance version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "natsort >= 5.0.1",
     "psutil >= 4.4.2",
     "zipstream >= 1.1.4",
-    "textdistance >= 4.2.0",
+    "textdistance==4.2.0",
 ]
 
 test_requires = [


### PR DESCRIPTION
# Description

Fix textdistance version to 4.2.0 to avoid unsupported versions for Python 3.5.

This PR fixes textdistance version to 4.2.0. More recent versions of the package are not supported in Python 3.5 anymore. This issue caused some problems during deployment of new dev environments.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
