### PR TITLE
hotfix to permit lti without ssl

### DIFF
--- a/inginious/frontend/lti_request_validator.py
+++ b/inginious/frontend/lti_request_validator.py
@@ -5,7 +5,7 @@ from pymongo.errors import DuplicateKeyError
 
 
 class LTIValidator(RequestValidator):  # pylint: disable=abstract-method
-    enforce_ssl = True
+    enforce_ssl = False
     client_key_length = (1, 30)
     nonce_length = (20, 64)
     realms = [""]


### PR DESCRIPTION
# Description

This hotfix ensure to permit lti validate request without ssl verification in a provitional production environment


## Type of change

Hotfix
