### PR TITLE
remove requests logs on lti and enforce https on lti requests

### DIFF
--- a/inginious/frontend/lti_tool_provider.py
+++ b/inginious/frontend/lti_tool_provider.py
@@ -18,5 +18,5 @@ class LTIWebPyToolProvider(ToolProvider):
                         k.upper().startswith('HTTP_') or
                         k.upper().startswith('CONTENT_')])
 
-        url = web.ctx.home + web.ctx.fullpath
+        url = "https://" + web.ctx.host + web.ctx.fullpath
         return cls.from_unpacked_request(secret, params, url, headers)

--- a/inginious/frontend/pages/lti.py
+++ b/inginious/frontend/pages/lti.py
@@ -214,11 +214,9 @@ class LTILaunchPage(INGIniousPage):
         try:
             test = LTIWebPyToolProvider.from_webpy_request()
             validator = LTIValidator(self.database.nonce, course.lti_keys())
-            verified, request = test.is_valid_request(validator)
+            verified = test.is_valid_request(validator)
         except Exception as e:
             self.logger.debug("Exception on _parse_lti_data: " + str(e))
-            self.logger.debug("Request object: " + str(request))
-            self.logger.debug("Request signature method: " + str(request.signature_method))
             self.logger.exception("...")
             self.logger.info("Error while validating LTI request for %s", str(post_input))
             raise web.forbidden(_("Error while validating LTI request"))
@@ -256,13 +254,9 @@ class LTILaunchPage(INGIniousPage):
                                                               context_title, context_label)
             loggedin = self.user_manager.attempt_lti_login()
 
-            self.logger.info("REQUEST: " + str(request))
-            self.logger.info("REQUEST: " + str(request.signature_method))
             
             return session_id, loggedin
         else:
-            self.logger.info("REQUEST: " + str(request))
-            self.logger.info("REQUEST: " + str(request.signature_method))
             self.logger.info("Couldn't validate LTI request")
             raise web.forbidden(_("Couldn't validate LTI request"))
 


### PR DESCRIPTION
# Description

Hotfix to ensure LTI on AWS
Now the LTI requests are forced to be https in order to validate them with the HMAC-SHA1 signature

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


